### PR TITLE
Fix evaluate.py and put dataset sizes inside params

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -5,7 +5,7 @@ import os
 
 import tensorflow as tf
 
-from model.input_fn import input_fn
+from model.input_fn import test_input_fn
 from model.model_fn import model_fn
 from model.utils import Params
 
@@ -27,22 +27,12 @@ if __name__ == '__main__':
     assert os.path.isfile(json_path), "No json configuration file found at {}".format(json_path)
     params = Params(json_path)
 
-    # Create the input data pipeline
-    tf.logging.info("Creating the datasets...")
-    data = tf.contrib.learn.datasets.mnist.load_mnist(args.data_dir)
-
-    # Specify the sizes of the dataset we evaluate on
-    params.eval_size = data.test.num_examples
-
-    # Create the test input function
-    test_input_fn = lambda: input_fn(False, data.test.images, data.test.labels, params)
-
     # Define the model
     tf.logging.info("Creating the model...")
     estimator = tf.estimator.Estimator(model_fn, params=params, model_dir=args.model_dir)
 
     # Evaluate the model on the test set
     tf.logging.info("Evaluation on the test set.")
-    res = estimator.evaluate(test_input_fn)
+    res = estimator.evaluate(lambda: test_input_fn(args.data_dir, params))
     for key in res:
         print("{}: {}".format(key, res[key]))

--- a/experiments/base_model/params.json
+++ b/experiments/base_model/params.json
@@ -13,6 +13,8 @@
 
     "image_size": 28,
     "num_labels": 10,
+    "train_size": 50000,
+    "eval_size": 10000,
 
     "num_parallel_calls": 4,
     "save_summary_steps": 50

--- a/train.py
+++ b/train.py
@@ -28,11 +28,6 @@ if __name__ == '__main__':
     assert os.path.isfile(json_path), "No json configuration file found at {}".format(json_path)
     params = Params(json_path)
 
-    # Specify the sizes of the dataset we train on and evaluate on
-    # TODO: this should be in the parameters file or somewhere
-    params.train_size = 50000
-    params.eval_size = 10000
-
     # Define the model
     tf.logging.info("Creating the model...")
     config = tf.estimator.RunConfig(tf_random_seed=230,


### PR DESCRIPTION
Great repository and blog post!

This pull request changes 2 things:

- Fixes `evaluate.py` since it wasn't running because of the data input_fn
- Addresses the *TODO* about putting the dataset sizes inside the parameters files